### PR TITLE
Jason fun888 patch 1  fix the mismatched security hash

### DIFF
--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -457,7 +457,7 @@ class erLhcoreClassExtensionFbmessenger {
 	                $hash = md5($file->name.'_'.$file->chat_id);
 	                
 	                $elements = [
-                        new Tgallice\FBMessenger\Model\Button\WebUrl(erTranslationClassLhTranslation::getInstance()->getTranslation('file/file','Download'), 'https://devmysql.livehelperchat.com' . erLhcoreClassDesign::baseurl('file/downloadfile')."/{$file->id}/{$hash}" )
+                        new Tgallice\FBMessenger\Model\Button\WebUrl(erTranslationClassLhTranslation::getInstance()->getTranslation('file/file','Download'), 'https://chat.segwaydiscovery.com' . erLhcoreClassDesign::baseurl('file/downloadfile')."/{$file->id}/{$hash}" )
                     ];
 	                	                
                     $template = new Tgallice\FBMessenger\Model\Attachment\Template\Button(erTranslationClassLhTranslation::getInstance()->getTranslation('file/file','Download').' - '.htmlspecialchars($file->upload_name).' ['.$file->extension.']', $elements);

--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -446,15 +446,9 @@ class erLhcoreClassExtensionFbmessenger {
 	        list($fileID,$hash) = explode('_',$fileKey);
 	        try {
 	            $file = erLhcoreClassModelChatFile::fetch($fileID);
-	        
-	            // AWS plugin changes file name, but we always use original name
-	            $parts = explode('/', $file->name);
-	            end($parts);
-	            $name = end($parts);
-	            	
+
 	            // Check that user has permission to see the chat. Let say if user purposely types file bbcode
-	            if ($hash == md5($name.'_'.$file->chat_id)) {
-	                $hash = md5($file->name.'_'.$file->chat_id);
+	            if ($hash == $file->security_hash) {
 	                
 	                $elements = [
                         new Tgallice\FBMessenger\Model\Button\WebUrl(erTranslationClassLhTranslation::getInstance()->getTranslation('file/file','Download'), 'https://chat.segwaydiscovery.com' . erLhcoreClassDesign::baseurl('file/downloadfile')."/{$file->id}/{$hash}" )


### PR DESCRIPTION
I found another issue after last fix that I can NOT download a file from the file_url, cause there are several places need to check the $file->security_hash, and each of them should be updated.

It's up to the erLhcoreClassModelChatFile Class to make rule of the security_hash, every other just get the it for checking permission.

Please check it, thanks!